### PR TITLE
SH-617: Add error message in response params, as per the sunbird response struction

### DIFF
--- a/sb-utils/src/main/java/org.sunbird/message/ResponseCode.java
+++ b/sb-utils/src/main/java/org.sunbird/message/ResponseCode.java
@@ -21,4 +21,14 @@ public enum ResponseCode {
   public int getCode() {
     return this.code;
   }
+
+  public static ResponseCode getResponseCode(int code) {
+    ResponseCode[] codes = ResponseCode.values();
+    for (ResponseCode res : codes) {
+      if (res.code == code) {
+        return res;
+      }
+    }
+    return ResponseCode.RESOURCE_NOT_FOUND;
+  }
 }

--- a/sb-utils/src/main/java/org.sunbird/response/ResponseFactory.java
+++ b/sb-utils/src/main/java/org.sunbird/response/ResponseFactory.java
@@ -1,6 +1,8 @@
 package org.sunbird.response;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 import org.sunbird.exception.BaseException;
 import org.sunbird.message.Localizer;
@@ -23,7 +25,7 @@ public class ResponseFactory {
     if (request != null) {
       response.setId(getApiId(request.getPath()));
       response.setVer(request.getVer());
-      response.setTs(System.currentTimeMillis() + StringUtils.EMPTY);
+      response.setTs(getCurrentDate());
     }
     if (exception instanceof BaseException) {
       BaseException ex = (BaseException) exception;
@@ -69,9 +71,18 @@ public class ResponseFactory {
       }
       String temVal[] = uri.split("/");
       for (String str : temVal) {
-        builder.append(str + ".");
+        if (str.matches("[A-Za-z]+")) {
+          builder.append(str + ".");
+        }
       }
+      builder.deleteCharAt(builder.length() - 1);
     }
     return builder.toString();
+  }
+
+  public static String getCurrentDate() {
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSSZ");
+    simpleDateFormat.setLenient(false);
+    return simpleDateFormat.format(new Date());
   }
 }

--- a/service/app/controllers/ResponseHandler.java
+++ b/service/app/controllers/ResponseHandler.java
@@ -56,7 +56,7 @@ public class ResponseHandler {
     String apiId = ResponseFactory.getApiId(request.getPath());
     response.setId(apiId);
     response.setVer(JsonKey.API_VERSION);
-    response.setTs(System.currentTimeMillis() + "");
+    response.setTs(ResponseFactory.getCurrentDate());
     return Results.ok(Json.toJson(response));
   }
 }

--- a/service/app/controllers/ResponseHandler.java
+++ b/service/app/controllers/ResponseHandler.java
@@ -4,6 +4,7 @@ import org.apache.http.HttpStatus;
 import org.sunbird.request.Request;
 import org.sunbird.response.Response;
 import org.sunbird.response.ResponseFactory;
+import org.sunbird.util.JsonKey;
 import play.libs.Json;
 import play.mvc.Result;
 import play.mvc.Results;
@@ -46,12 +47,16 @@ public class ResponseHandler {
    */
   public static Result handleResponse(Object object, Request request) {
     if (object instanceof Response) {
-      return handleSuccessResponse((Response) object);
+      return handleSuccessResponse((Response) object, request);
     }
     return handleFailureResponse(object, request);
   }
 
-  private static Result handleSuccessResponse(Response response) {
+  private static Result handleSuccessResponse(Response response, Request request) {
+    String apiId = ResponseFactory.getApiId(request.getPath());
+    response.setId(apiId);
+    response.setVer(JsonKey.API_VERSION);
+    response.setTs(System.currentTimeMillis() + "");
     return Results.ok(Json.toJson(response));
   }
 }

--- a/service/test/controllers/CreateGroupControllerTest.java
+++ b/service/test/controllers/CreateGroupControllerTest.java
@@ -32,6 +32,12 @@ public class CreateGroupControllerTest extends BaseApplicationTest {
     member.put(JsonKey.USER_ID, "userID");
     members.add(member);
     reqMap.put(JsonKey.MEMBERS, members);
+    List<Map<String, Object>> activities = new ArrayList<>();
+    Map<String, Object> activity = new HashMap<>();
+    activity.put(JsonKey.TYPE, "COURSE");
+    activity.put(JsonKey.ID, "courseId");
+    activities.add(activity);
+    reqMap.put(JsonKey.ACTIVITIES, activities);
     request.put("request", reqMap);
     Result result = performTest("/v1/group/create", "POST", request);
     assertTrue(getResponseStatus(result) == Response.Status.OK.getStatusCode());


### PR DESCRIPTION
for example : 

`{
    "id": "api.group.create",
    "ver": null,
    "ts": "2020-07-08 19:07:12:502+0530",
    "params": {
        "resmsgid": null,
        "msgid": "e2126e71-9eb8-46d9-8360-469a1adad817",
        "err": "CLIENT_ERROR",
        "status": "CLIENT_ERROR",
        "errmsg": "MANDATORY PARAM members[0].userId IS MISSING"
    },
    "result": {},
    "responseCode": 400
}`