### PR TITLE
SC-2000 changing groups service cassandra keyspace to sunbird_groups

### DIFF
--- a/group-actors/src/main/java/org/sunbird/util/DBUtil.java
+++ b/group-actors/src/main/java/org/sunbird/util/DBUtil.java
@@ -9,7 +9,7 @@ import org.sunbird.helper.CassandraConnectionMngrFactory;
 
 public class DBUtil {
   public static final Map<String, DbInfo> dbInfoMap = new HashMap<>();
-  public static final String KEY_SPACE_NAME = "sunbird";
+  public static final String KEY_SPACE_NAME = JsonKey.SUNBIRD_GROUPS;
 
   private static void initializeDBProperty() {
     // setting db info (keyspace , table) into static map

--- a/group-actors/src/test/java/org/sunbird/actors/EmbeddedCassandra.java
+++ b/group-actors/src/test/java/org/sunbird/actors/EmbeddedCassandra.java
@@ -14,7 +14,7 @@ import org.sunbird.util.JsonKey;
 
 public class EmbeddedCassandra {
 
-  static final String KEYSPACE = "sunbird";
+  static final String KEYSPACE = JsonKey.SUNBIRD_GROUPS;
   static final String GROUP_TABLE = "group";
   static final String MEMBER_TABLE = "group_member";
   static final String USER_GROUP = "user_group";

--- a/group-actors/src/test/resources/createGroup.cql
+++ b/group-actors/src/test/resources/createGroup.cql
@@ -1,5 +1,5 @@
-CREATE TABLE IF NOT EXISTS sunbird.group (id text, name text, description text, activities set<frozen <map<text,text>>>, status text, membershipType text, createdBy text, createdOn timestamp, updatedBy text, updatedOn timestamp, PRIMARY KEY (id));
+CREATE TABLE IF NOT EXISTS sunbird_groups.group (id text, name text, description text, activities set<frozen <map<text,text>>>, status text, membershipType text, createdBy text, createdOn timestamp, updatedBy text, updatedOn timestamp, PRIMARY KEY (id));
 
-CREATE TABLE IF NOT EXISTS sunbird.group_member(groupId text, role text, userId text, status text, createdBy text, createdOn timestamp , updatedBy text, updatedOn timestamp, removedBy text, removedOn timestamp, PRIMARY KEY(groupId, role, userId));
+CREATE TABLE IF NOT EXISTS sunbird_groups.group_member(groupId text, role text, userId text, status text, createdBy text, createdOn timestamp , updatedBy text, updatedOn timestamp, removedBy text, removedOn timestamp, PRIMARY KEY(groupId, role, userId));
 
-CREATE TABLE IF NOT EXISTS sunbird.user_group(userId text, groupId set<text>, PRIMARY KEY(userId));
+CREATE TABLE IF NOT EXISTS sunbird_groups.user_group(userId text, groupId set<text>, PRIMARY KEY(userId));

--- a/sb-utils/src/main/java/org/sunbird/util/JsonKey.java
+++ b/sb-utils/src/main/java/org/sunbird/util/JsonKey.java
@@ -31,7 +31,7 @@ public interface JsonKey {
   String REQ_ID = "reqId";
   String USER_DB = "user_db";
   String SUNBIRD_CASSANDRA_IP = "sunbird_cassandra_host";
-  String SUNBIRD = "sunbird";
+  String SUNBIRD_GROUPS = "sunbird_groups";
   String GROUP_ID = "groupId";
   String GROUP_DESC = "description";
   String GROUP_NAME = "name";


### PR DESCRIPTION
Altered sunbird keyspace to sunbird_groups keyspace.
All the group related data now will be keep in sunbird_groups keyspace.