### PR TITLE
SC-1966 Fix device-id key value

### DIFF
--- a/sb-utils/src/main/java/org/sunbird/util/JsonKey.java
+++ b/sb-utils/src/main/java/org/sunbird/util/JsonKey.java
@@ -6,32 +6,21 @@ import java.util.List;
 /** This interface will contains all the constants that's used throughout this application. */
 public interface JsonKey {
 
-  String CLASS = "class";
-  String DATA = "data";
-  String EKS = "eks";
   String ID = "id";
-  String LEVEL = "level";
   String MESSAGE = "message";
   String METHOD = "method";
   String REQUEST_MESSAGE_ID = "msgId";
-  String STACKTRACE = "stacktrace";
   String VER = "ver";
   String OK = "ok";
   String LOG_LEVEL = "logLevel";
   String ERROR = "error";
   String EMPTY_STRING = "";
   String RESPONSE = "response";
-  String ADDRESS = "address";
   String KEY = "key";
-  String ERROR_MSG = "error_msg";
-  String ATTRIBUTE = "attribute";
-  String ERRORS = "errors";
   String SUCCESS = "success";
   String API_VERSION = "v1";
-  String REQ_ID = "reqId";
   String USER_DB = "user_db";
   String SUNBIRD_CASSANDRA_IP = "sunbird_cassandra_host";
-  String SUNBIRD = "sunbird";
   String GROUP_ID = "groupId";
   String GROUP_DESC = "description";
   String GROUP_NAME = "name";
@@ -104,7 +93,6 @@ public interface JsonKey {
   String SUNBIRD_CS_AUTH_KEY = "sunbird_cs_token_key";
   String FIELDS = "fields";
   String AUTHORIZATION = "Authorization";
-  String HEADERS = "headers";
   String ACTIVITY_INFO = "activityInfo";
   String IDENTIFIER = "identifier";
   String FIRSTNAME = "firstName";
@@ -116,14 +104,11 @@ public interface JsonKey {
   Object API_CALL = "API_CALL";
   String USER = "user";
   String ACTOR_TYPE = "actorType";
-  String ROOT_ORG_ID = "rootOrgId";
-  String ROLLUP = "rollup";
   String APP_ID = "appId";
   String DEVICE_ID = "did";
   String ACTOR_ID = "actorId";
   String DEFAULT_CONSUMER_ID = "internal";
   String CONSUMER = "consumer";
-  String ADDITIONAL_INFO = "ADDITIONAL_INFO";
   String UPDATE = "update";
   String CREATE = "create";
   String DELETE = "delete";

--- a/sb-utils/src/main/java/org/sunbird/util/JsonKey.java
+++ b/sb-utils/src/main/java/org/sunbird/util/JsonKey.java
@@ -71,7 +71,6 @@ public interface JsonKey {
   String SSO_REALM = "sso.realm";
   String SSO_URL = "sso.url";
   String SSO_USERNAME = "sso.username";
-  String MESSAGE_ID = "X-msgId";
   String ANONYMOUS = "Anonymous";
   List<String> USER_UNAUTH_STATES = Arrays.asList(JsonKey.UNAUTHORIZED, JsonKey.ANONYMOUS);
   String REQUEST = "request";
@@ -81,7 +80,6 @@ public interface JsonKey {
   String DOT_SEPARATOR = ".";
   String SHA_256_WITH_RSA = "SHA256withRSA";
   String REQUEST_ID = "requestId";
-  String VERSION_2 = "v2";
   String ACCESS_TOKEN_PUBLICKEY_BASEPATH = "accesstoken.publickey.basepath";
   String ACCESS_TOKEN_PUBLICKEY_KEYPREFIX = "accesstoken.publickey.keyprefix";
   String ACCESS_TOKEN_PUBLICKEY_KEYCOUNT = "accesstoken.publickey.keycount";
@@ -109,8 +107,6 @@ public interface JsonKey {
   String HEADERS = "headers";
   String ACTIVITY_INFO = "activityInfo";
   String IDENTIFIER = "identifier";
-  String CONTENT_SERVICE = "content-service";
-  String CONTENT_TYPE = "contentType";
   String FIRSTNAME = "firstName";
   String LASTNAME = "lastName";
   String USER_SERVICE_SYSTEM_SETTING_URL = "sunbird_us_system_setting_url";
@@ -123,7 +119,7 @@ public interface JsonKey {
   String ROOT_ORG_ID = "rootOrgId";
   String ROLLUP = "rollup";
   String APP_ID = "appId";
-  String DEVICE_ID = "deviceId";
+  String DEVICE_ID = "did";
   String ACTOR_ID = "actorId";
   String DEFAULT_CONSUMER_ID = "internal";
   String CONSUMER = "consumer";


### PR DESCRIPTION
`X-Device-Id` header contains the mobile device id. This is populated by the mobile app.
This header was read and put in a key `did`. While sending telemetry, the `device-id` key was referred resulting in a miss of this value.