### PR TITLE
SH-1150: Modified check maximum group limit  condition

### DIFF
--- a/group-actors/src/main/java/org/sunbird/util/GroupUtil.java
+++ b/group-actors/src/main/java/org/sunbird/util/GroupUtil.java
@@ -85,7 +85,7 @@ public class GroupUtil {
     }
     int maxGroupLimit =
         Integer.parseInt(PropertiesCache.getInstance().getProperty(JsonKey.MAX_GROUP_LIMIT));
-    if (groupCount > maxGroupLimit) {
+    if (groupCount >= maxGroupLimit) {
       logger.error("List of groups exceeded the max limit:{}", groupCount);
       throw new BaseException(
           IResponseMessage.Key.EXCEEDED_GROUP_MAX_LIMIT,


### PR DESCRIPTION
No need to make changes for member and activity limit conditions. confirmed with @reshmi-nair 

 it was possible to do configured max_group_limit plus 1 should be the condition to meet EXCEEDED_GROUP_MAX_LIMIT. this is fixed in the PR
