### PR TITLE
SBCOSS-468: Sunbird Groups service  - create Github actions to publish docker image to GHCR

### DIFF
--- a/.github/BUILD.md
+++ b/.github/BUILD.md
@@ -1,0 +1,78 @@
+# GitHub Action: Build and Deploy
+
+## Overview
+This GitHub Action automates the build and deployment process for the Groups service. It builds the project, runs tests, packages the application, and pushes a Docker image to GitHub Container Registry (GHCR).
+
+## Usage
+The action will automatically build and deploy your service whenever a new tag is pushed.
+
+## Steps
+
+1. **Set up JDK 11**
+   - Configures the environment with JDK 11 using the `actions/setup-java` action with Temurin distribution.
+
+2. **Checkout code**
+   - Checks out the repository code with full commit history.
+
+3. **Cache Maven packages**
+   - Caches Maven dependencies to speed up subsequent builds.
+
+4. **Build and run test cases**
+   ```bash
+   mvn clean install -DskipTests
+   cd service
+   mvn clean verify surefire-report:report
+   ```
+   - Generates test reports for the test results.
+
+5. **Package build artifact**
+   - Packages the application using Play Framework's `dist` goal.
+   ```bash
+   mvn -f service/pom.xml play2:dist
+   ```
+
+6. **Upload artifact**
+   - Uploads the packaged application as a GitHub Actions artifact named `groups-service-dist`.
+
+7. **Extract image tag details**
+   - Prepares Docker image name and tags based on the repository name and reference.
+
+8. **Log in to GitHub Container Registry**
+   - Authenticates to GHCR using the provided GitHub token.
+
+9. **Build and push Docker image**
+   - Builds the Docker image using the provided Dockerfile and pushes it to GHCR with the appropriate tags.
+
+## Environment Variables
+- `REGISTRY`: The GitHub Container Registry URL (ghcr.io)
+- `IMAGE_NAME`: Auto-generated based on the repository name (e.g., ghcr.io/username/repo)
+- `IMAGE_TAG`: Auto-generated based on the git reference (branch name or tag)
+
+## Permissions
+This workflow requires the following permissions:
+- `contents: read` - To read the repository contents
+- `packages: write` - To push Docker images to GitHub Container Registry
+
+## How to Use the Docker Image
+
+1. **Pull the Docker Image**:
+   ```bash
+   docker pull ghcr.io/<repository-name>:<tag>
+   ```
+   Replace `<repository-name>` and `<tag>` with the appropriate values.
+
+2. **Run the Docker Container**:
+   ```bash
+   docker run -d -p <host-port>:9000 ghcr.io/<repository-name>:<tag>
+   ```
+   Replace `<host-port>` with your desired port number.
+
+3. **Access the Application**:
+   Once the container is running, you can access the application at `http://localhost:<host-port>`.
+
+## Notes
+- The workflow uses Ubuntu latest runner.
+- Maven dependencies are cached to improve build performance.
+- The Docker image is built using the Dockerfile in the repository root.
+- The workflow automatically handles repository name and tag generation for Docker images.
+- Test reports are generated and made available in the GitHub Actions UI.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,105 @@
+name: Build and Deploy
+
+on:
+  push:
+    tags:
+      - '*'  # Trigger this workflow on any git tag push
+
+jobs:
+  ghcr-build-and-deploy:
+    runs-on: ubuntu-latest  # Use the latest available Ubuntu runner
+
+    permissions:
+      contents: read         # Allows reading repository contents
+      packages: write        # Allows writing to GitHub Packages (GHCR)
+
+    env:
+      REGISTRY: ghcr.io      # Define GitHub Container Registry as the target registry
+
+    steps:
+      # Set up Java Development Kit (JDK) 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'  # Use the Temurin distribution of OpenJDK
+          java-version: '11'       # Set Java version to 11
+
+      # Check out the repository code
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Ensure full history is fetched, needed for tags
+
+      # Cache local Maven dependencies to speed up builds
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Build the project and generate test reports (without skipping tests)
+      - name: Build and run test cases
+        run: | 
+          mvn clean install -DskipTests  # Initial install, skipping tests
+          cd service
+          mvn clean verify surefire-report:report  # Run tests and generate reports
+
+      # Generate and display a detailed test report in the GitHub Actions UI
+      - name: Test Summary
+        uses: dorny/test-reporter@v2.1.0
+        if: always()  # Ensure this runs even if previous steps fail
+        with:
+          name: Test Results
+          path: '**/surefire-reports/*.xml'  # Look for JUnit XML test reports
+          reporter: java-junit
+          fail-on-error: false
+          only-summary: false
+          list-tests: 'all'  # Include full list of tests in the summary
+
+      # Package the application using Play Framework's dist goal
+      - name: Package build artifact (Play dist)
+        run: mvn -f service/pom.xml play2:dist
+
+      # Move the packaged artifact to the root directory for easier access
+      - name: Moving the artifact to the root directory
+        run: |
+          mv service/target/group-service-1.0.0-dist.zip .
+
+      # Upload the packaged artifact to GitHub as a workflow artifact
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: groups-service-dist
+          path: |
+            service/target/group-service-*-dist.zip
+
+      # Extract Docker image name and tag from GitHub variables
+      - name: Extract image tag details
+        id: image_vars
+        run: |
+          REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
+          IMAGE_TAG=${TAG_LOWER}
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      # Authenticate Docker to GitHub Container Registry (GHCR)
+      - name: Log in to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build the Docker image and push it to GHCR
+      - name: Build and push Docker image to GHCR
+        uses: docker/build-push-action@v4
+        with:
+          context: .              # Docker context (root of the repository)
+          file: ./Dockerfile      # Path to Dockerfile
+          push: true              # Push the image to the registry
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}  # Full image tag


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to the `groups-service` repository.

**Build and Deploy (`build.yml`):**  
Triggers when a Git tag is pushed.  
Builds the project, packages the artifact, builds a Docker image, and pushes it to GitHub Container Registry (GHCR).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Create GitHub Actions workflows to automatically build, test, package, and deploy the Sunbird Groups service Docker image to GitHub Container Registry (GHCR).

### Why are these changes being made?

These changes automate the CI/CD process for the Sunbird Groups service, ensuring consistent builds and deployments upon new tag pushes. The approach leverages GitHub Actions for a streamlined, efficient workflow, with caching to improve performance and automatic environment setup, making it robust and easy to maintain.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->