### PR TITLE
To fix the docker image name which is pushed to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,10 @@ jobs:
         id: image_vars
         run: |
           REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA=$(git rev-parse HEAD | cut -c1-7)
           TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
           IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
-          IMAGE_TAG=${TAG_LOWER}
+          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}_${GITHUB_RUN_NUMBER}
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
 


### PR DESCRIPTION
This PR fixes the docker image tag name where the commit SHA was not being added previously.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the Docker image tagging process in the GitHub Actions workflow to include a short SHA and the GitHub run number in the IMAGE_TAG.

### Why are these changes being made?

These changes ensure that each Docker image pushed to the GitHub Container Registry (GHCR) has a unique tag which includes a short commit SHA and the workflow run number, preventing collisions and aiding in precise version identification and traceability. This approach addresses potential issues with identically named tags across different runs or branches.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->