### PR TITLE
Upgrade kafka-clients dependency for Kafka 4.x compatibility

### DIFF
--- a/sb-telemetry-utils/pom.xml
+++ b/sb-telemetry-utils/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.8.1</version>
+            <version>3.7.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
## Summary

This PR upgrades the kafka-clients dependency to a version compatible with Kafka 4.x.